### PR TITLE
Rarible NFT metadata support

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -132,8 +132,8 @@ async function getTokenMetadata(contractAddress, tokenId = 0) {
         rawMetadata.icon ||
         rawMetadata.iconUri ||
         rawMetadata.iconUrl ||
-        rawMetadata.artifactUri ||
-        rawMetadata.displayUri,
+        rawMetadata.displayUri ||
+        rawMetadata.artifactUri,
       artifactUri: rawMetadata.artifactUri,
     };
 

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -131,7 +131,9 @@ async function getTokenMetadata(contractAddress, tokenId = 0) {
         rawMetadata.logo ||
         rawMetadata.icon ||
         rawMetadata.iconUri ||
-        rawMetadata.iconUrl,
+        rawMetadata.iconUrl ||
+        rawMetadata.artifactUri ||
+        rawMetadata.displayUri,
       artifactUri: rawMetadata.artifactUri,
     };
 


### PR DESCRIPTION
https://www.notion.so/madfissolutions/Image-of-NFT-that-was-minted-on-the-Rarible-is-not-rendered-on-the-Temple-Wallet-646951cbbb3849e9a291f7eec8af5d36