### PR TITLE
Node.js v18. -- experimental fetch flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN yarn
 COPY . .
 EXPOSE 3000
 
-CMD [ "node", "--experimental-fetch", "src/index.js" ]
+CMD [ "node", "src/index.js" ]


### PR DESCRIPTION
Faced this issue with version 17: https://github.com/nodejs/node/issues/46525

Pay attention to this unresolved issue with OpenSSL: https://github.com/nodejs/node/issues/43128

It is reported to be present in `Node.js v17.9.0`, which we did not experience, thus trying v18.